### PR TITLE
chore: adicionar Prettier e Husky (pre-commit)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,4 +5,5 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = lf
 max_line_length = 90

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npx prettier --write .
+npx eslint .

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+complaints.routes.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "lf"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+import js from "@eslint/js";
+import globals from "globals";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+  {
+    files: ["**/*.{js,mjs,cjs}"],
+    plugins: { js },
+    extends: ["js/recommended"],
+    languageOptions: { globals: globals.node },
+  },
+]);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "lint:check": "prettier --check .",
-    "lint:fix": "prettier --write ."
+    "lint:fix": "prettier --write .",
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +23,10 @@
     "multer": "^2.1.1"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.1.0",
+    "globals": "^17.4.0",
+    "husky": "^9.1.7",
     "nodemon": "^3.1.14",
     "prettier": "^3.5.3"
   }


### PR DESCRIPTION
### chore: adicionar Prettier e Husky (pre-commit)

- Configura formatação automática com prettier
- Adiciona hooks de commit com husky
- Garante código formatado antes de cada commit (pre-commit)
- Melhora consistência e qualidade do projeto sem alterar lógica de negócio