### PR TITLE
Feature/adicionar campo tipo animal e integrar lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-npx prettier --write .
-npx eslint .
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
     "lint:fix": "prettier --write .",
     "prepare": "husky"
   },
+  "lint-staged": {
+    "*.{js,ts,jsx,tsx,json,md}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -27,6 +33,7 @@
     "eslint": "^10.1.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "nodemon": "^3.1.14",
     "prettier": "^3.5.3"
   }

--- a/src/modules/complaints/complaints.service.js
+++ b/src/modules/complaints/complaints.service.js
@@ -4,11 +4,21 @@ import { COMPLAINT_STATUS } from "./../../shared/types/complaint.status.js";
 import { ValidationError } from "../../shared/errors/validationError.js";
 import { ERROR_CODES } from "../../shared/errors/errorCodes.js";
 import { COMPLAINT_FIELDS } from "../../shared/types/complaint.fields.js";
+import { COMPLAINT_ANIMALS } from "../../shared/types/complaint.animals.js";
 
-export const create = async ({ title, description, location, type, photos, status = COMPLAINT_TYPES.OPEN }) => {
+export const create = async ({
+  title,
+  description,
+  location,
+  type,
+  animal,
+  photos,
+  status = COMPLAINT_TYPES.OPEN,
+}) => {
   const missingFields = [];
   const validTypes = Object.values(COMPLAINT_TYPES);
   const validStatuses = Object.values(COMPLAINT_STATUS);
+  const validAnimals = Object.values(COMPLAINT_ANIMALS);
 
   if (!title) missingFields.push("title");
   if (!description) missingFields.push("description");
@@ -16,6 +26,7 @@ export const create = async ({ title, description, location, type, photos, statu
   if (!type) missingFields.push("type");
   if (!location.latitude) missingFields.push("location.latitude");
   if (!location.longitude) missingFields.push("location.longitude");
+  if (!animal) missingFields.push("animal");
 
   if (missingFields.length > 0) {
     throw new ValidationError(
@@ -38,10 +49,18 @@ export const create = async ({ title, description, location, type, photos, statu
     );
   }
 
+  if (animal && !validAnimals.includes(animal)) {
+    throw new ValidationError(
+      `Animal inválido. Valores aceitos: ${validAnimals.join(", ")}`,
+      ERROR_CODES.COMPLAINT_VALIDATION,
+    );
+  }
+
   const complaint = {
     title,
     description,
     type,
+    animal,
     location,
     status,
     photos: photos || [],
@@ -63,7 +82,12 @@ export const getDetail = async (id) => {
 export const patch = async (id, body) => {
   const validTypes = Object.values(COMPLAINT_TYPES);
   const validStatuses = Object.values(COMPLAINT_TYPES);
+  const validAnimals = Object.values(COMPLAINT_ANIMALS);
   const allowedFields = Object.values(COMPLAINT_FIELDS);
+
+  console.log("body recebido:", body);
+  console.log("campos do body:", Object.keys(body));
+  console.log("campos permitidos:", Object.values(COMPLAINT_FIELDS));
 
   if (Object.keys(body).length === 0) {
     throw new ValidationError(
@@ -95,6 +119,13 @@ export const patch = async (id, body) => {
   if (body.status && !validStatuses.includes(body.status)) {
     throw new ValidationError(
       `Status inválido. Valores aceitos: ${validStatuses.join(", ")}`,
+      ERROR_CODES.COMPLAINT_VALIDATION,
+    );
+  }
+
+  if (body.animal && !validAnimals.includes(body.animal)) {
+    throw new ValidationError(
+      `Animal inválido. Valores aceitos: ${validAnimals.join(", ")}`,
       ERROR_CODES.COMPLAINT_VALIDATION,
     );
   }

--- a/src/shared/types/complaint.animals.js
+++ b/src/shared/types/complaint.animals.js
@@ -1,0 +1,6 @@
+export const COMPLAINT_ANIMALS = {
+  DOG: "cachorro",
+  CAT: "gato",
+  BIRD: "passaro",
+  OTHER: "outro",
+};

--- a/src/shared/types/complaint.fields.js
+++ b/src/shared/types/complaint.fields.js
@@ -2,6 +2,7 @@ export const COMPLAINT_FIELDS = {
   TITLE: "title",
   DESCRIPTION: "description",
   TYPE: "type",
+  ANIMAL: "animal",
   LOCATION: "location",
   STATUS: "status",
   PHOTOS: "photos",

--- a/src/shared/types/complaint.status.js
+++ b/src/shared/types/complaint.status.js
@@ -1,5 +1,5 @@
 export const COMPLAINT_STATUS = {
-  OPEN: "open",
-  CLOSED: "closed",
-  RESOLVED: "resolved",
+  OPEN: "aberto",
+  CLOSED: "fechado",
+  RESOLVED: "resolvido",
 };

--- a/src/shared/types/complaint.types.js
+++ b/src/shared/types/complaint.types.js
@@ -1,7 +1,7 @@
 export const COMPLAINT_TYPES = {
-  ABANDONMENT: "abandonment",
-  PHYSICAL_ABUSE: "physical abuse",
-  NEGLECT: "neglect",
-  HOARDING: "hoarding",
-  OTHER: "other",
+  ABANDONMENT: "abandono",
+  PHYSICAL_ABUSE: "maus-tratos fisicos",
+  NEGLECT: "negligencia",
+  HOARDING: "acumulo de animais",
+  OTHER: "outro",
 };


### PR DESCRIPTION
## O que foi feito

Adiciona o campo `animal` ao service de denúncias e migra o pre-commit para Husky + lint-staged.

## Mudanças
- Adiciona `complaint.animals.js` com os tipos de animais válidos
- Atualiza `complaints.service.js` para aceitar e validar o campo `animal` no create
- Atualiza `complaints.service.js` para validar o campo `animal` no patch
- Atualiza `.husky/pre-commit` para rodar lint-staged
- Adiciona configuração `lint-staged` no `package.json` para Prettier e ESLint
- Traduz arquivos da pasta types para portugues

closes #26 