### PR TITLE
feat(complaints): adiciona suporte a localização com GeoPoint 

### DIFF
--- a/src/modules/complaints/complaints.repository.js
+++ b/src/modules/complaints/complaints.repository.js
@@ -1,3 +1,4 @@
+import admin from "firebase-admin";
 import { db } from "../../config/firebase.js";
 import { env } from "../../config/env.js";
 import { NotFoundError } from "../../shared/errors/not-found.error.js";
@@ -5,26 +6,58 @@ import { ERROR_CODES } from "../../shared/types/error.codes.js";
 import { serialize } from "../../shared/utils/firestore.util.js";
 
 const COLLECTION = `${env.firebase.collectionPrefix}complaints`;
+const { GeoPoint } = admin.firestore;
+
+const prepareLocationToSave = (data) => {
+  if (!data.location) return data;
+
+  const { latitude, longitude } = data.location;
+
+  if (typeof latitude !== "number" || typeof longitude !== "number") {
+    return data;
+  }
+
+  return {
+    ...data,
+    location: new GeoPoint(latitude, longitude),
+  };
+};
+
+const prepareLocationToReturn = (complaint) => {
+  if (!complaint?.location) return complaint;
+
+  return {
+    ...complaint,
+    location: {
+      latitude: complaint.location.latitude,
+      longitude: complaint.location.longitude,
+    },
+  };
+};
 
 export const create = async (data) => {
-  const docRef = await db.collection(COLLECTION).add(data);
-  return {
+  const preparedData = prepareLocationToSave(data);
+
+  const docRef = await db.collection(COLLECTION).add(preparedData);
+  return prepareLocationToReturn({
     id: docRef.id,
-    ...data,
+    ...preparedData,
     createdAt: data.createdAt.toISOString(),
     updatedAt: data.updatedAt.toISOString(),
-  };
+  });
 };
 
 export const getAll = async () => {
   const snapshot = await db.collection(COLLECTION).get();
-  return snapshot.docs.map((doc) => serialize(doc.id, doc.data()));
+  return snapshot.docs.map((doc) =>
+    prepareLocationToReturn(serialize(doc.id, doc.data())),
+  );
 };
 
 export const getDetail = async (id) => {
   const docRef = await db.collection(COLLECTION).doc(id).get();
   if (!docRef.exists) throw new NotFoundError(ERROR_CODES.COMPLAINT_NOT_FOUND);
-  return serialize(docRef.id, docRef.data());
+  return prepareLocationToReturn(serialize(docRef.id, docRef.data()));
 };
 
 export const patch = async (id, data) => {
@@ -32,10 +65,12 @@ export const patch = async (id, data) => {
   const doc = await docRef.get();
   if (!doc.exists) throw new NotFoundError(ERROR_CODES.COMPLAINT_NOT_FOUND);
 
-  await docRef.update(data);
+  const preparedData = prepareLocationToSave(data);
+
+  await docRef.update(preparedData);
 
   const updatedDoc = (await docRef.get()).data();
-  return serialize(id, updatedDoc);
+  return prepareLocationToReturn(serialize(id, updatedDoc));
 };
 
 export const deleteComplaint = async (id) => {

--- a/src/validators/complaint.validator.js
+++ b/src/validators/complaint.validator.js
@@ -52,10 +52,17 @@ const prepareData = (req) => {
 };
 
 const parseLocation = (location) => {
-  if (typeof location !== "string" || !location.trim()) return location;
   try {
-    return JSON.parse(location);
+    const parsed = typeof location === "string" ? JSON.parse(location) : location;
+
+    const { latitude, longitude } = parsed || {};
+
+    if (typeof latitude !== "number" || typeof longitude !== "number") {
+      throw new Error();
+    }
+
+    return { latitude, longitude };
   } catch {
-    throw new ValidationError("Location inválido", ERROR_CODES.COMPLAINT_VALIDATION);
+    throw new ValidationError("Localização inválida", ERROR_CODES.COMPLAINT_VALIDATION);
   }
 };


### PR DESCRIPTION
Implementa suporte para receber e persistir coordenadas geográficas nas denúncias.

### O que foi feito:
- Recebimento de latitude e longitude no body
- Validação do campo location
- Conversão para GeoPoint no Firestore
- Retorno das coordenadas na API

### Objetivo:
Permitir integração com mapa e futuras consultas por proximidade.

closes #7 