### PR TITLE
refactor: simplificar serialização de GeoPoint e mover lógica para firestore.util

### DIFF
--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -10,3 +10,4 @@ admin.initializeApp({
 });
 
 export const db = admin.firestore();
+export const GeoPoint = admin.firestore.GeoPoint;

--- a/src/modules/complaints/complaints.repository.js
+++ b/src/modules/complaints/complaints.repository.js
@@ -1,63 +1,36 @@
-import admin from "firebase-admin";
-import { db } from "../../config/firebase.js";
+import { db, GeoPoint } from "../../config/firebase.js";
 import { env } from "../../config/env.js";
 import { NotFoundError } from "../../shared/errors/not-found.error.js";
 import { ERROR_CODES } from "../../shared/types/error.codes.js";
 import { serialize } from "../../shared/utils/firestore.util.js";
 
 const COLLECTION = `${env.firebase.collectionPrefix}complaints`;
-const { GeoPoint } = admin.firestore;
 
-const prepareLocationToSave = (data) => {
+const toGeoPoint = (data) => {
   if (!data.location) return data;
-
   const { latitude, longitude } = data.location;
-
-  if (typeof latitude !== "number" || typeof longitude !== "number") {
-    return data;
-  }
-
-  return {
-    ...data,
-    location: new GeoPoint(latitude, longitude),
-  };
-};
-
-const prepareLocationToReturn = (complaint) => {
-  if (!complaint?.location) return complaint;
-
-  return {
-    ...complaint,
-    location: {
-      latitude: complaint.location.latitude,
-      longitude: complaint.location.longitude,
-    },
-  };
+  return { ...data, location: new GeoPoint(latitude, longitude) };
 };
 
 export const create = async (data) => {
-  const preparedData = prepareLocationToSave(data);
-
-  const docRef = await db.collection(COLLECTION).add(preparedData);
-  return prepareLocationToReturn({
-    id: docRef.id,
-    ...preparedData,
-    createdAt: data.createdAt.toISOString(),
-    updatedAt: data.updatedAt.toISOString(),
+  const prepared = toGeoPoint(data);
+  const docRef = await db.collection(COLLECTION).add(prepared);
+  return serialize(docRef.id, {
+    ...prepared,
+    createdAt: data.createdAt,
+    updatedAt: data.updatedAt,
   });
 };
 
 export const getAll = async () => {
   const snapshot = await db.collection(COLLECTION).get();
-  return snapshot.docs.map((doc) =>
-    prepareLocationToReturn(serialize(doc.id, doc.data())),
-  );
+  return snapshot.docs.map((doc) => serialize(doc.id, doc.data()));
 };
 
 export const getDetail = async (id) => {
-  const docRef = await db.collection(COLLECTION).doc(id).get();
-  if (!docRef.exists) throw new NotFoundError(ERROR_CODES.COMPLAINT_NOT_FOUND);
-  return prepareLocationToReturn(serialize(docRef.id, docRef.data()));
+  const doc = await db.collection(COLLECTION).doc(id).get();
+  if (!doc.exists) throw new NotFoundError(ERROR_CODES.COMPLAINT_NOT_FOUND);
+  return serialize(doc.id, doc.data());
 };
 
 export const patch = async (id, data) => {
@@ -65,12 +38,11 @@ export const patch = async (id, data) => {
   const doc = await docRef.get();
   if (!doc.exists) throw new NotFoundError(ERROR_CODES.COMPLAINT_NOT_FOUND);
 
-  const preparedData = prepareLocationToSave(data);
+  const prepared = toGeoPoint(data);
+  await docRef.update(prepared);
 
-  await docRef.update(preparedData);
-
-  const updatedDoc = (await docRef.get()).data();
-  return prepareLocationToReturn(serialize(id, updatedDoc));
+  const updated = (await docRef.get()).data();
+  return serialize(id, updated);
 };
 
 export const deleteComplaint = async (id) => {

--- a/src/shared/utils/firestore.util.js
+++ b/src/shared/utils/firestore.util.js
@@ -1,6 +1,14 @@
+import { GeoPoint } from "../../config/firebase.js";
+
+const transformValue = (value) => {
+  if (value?.toDate) return value.toDate().toISOString();
+  if (value instanceof GeoPoint)
+    return { latitude: value.latitude, longitude: value.longitude };
+  return value;
+};
 export const serialize = (id, data) => ({
   id,
-  ...data,
-  createdAt: data.createdAt.toDate().toISOString(),
-  updatedAt: data.updatedAt.toDate().toISOString(),
+  ...Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [key, transformValue(value)]),
+  ),
 });

--- a/src/shared/utils/firestore.util.js
+++ b/src/shared/utils/firestore.util.js
@@ -6,6 +6,7 @@ const transformValue = (value) => {
     return { latitude: value.latitude, longitude: value.longitude };
   return value;
 };
+
 export const serialize = (id, data) => ({
   id,
   ...Object.fromEntries(

--- a/src/validators/complaint.validator.js
+++ b/src/validators/complaint.validator.js
@@ -52,16 +52,9 @@ const prepareData = (req) => {
 };
 
 const parseLocation = (location) => {
+  if (typeof location !== "string" || !location.trim()) return location;
   try {
-    const parsed = typeof location === "string" ? JSON.parse(location) : location;
-
-    const { latitude, longitude } = parsed || {};
-
-    if (typeof latitude !== "number" || typeof longitude !== "number") {
-      throw new Error();
-    }
-
-    return { latitude, longitude };
+    return JSON.parse(location);
   } catch {
     throw new ValidationError("Localização inválida", ERROR_CODES.COMPLAINT_VALIDATION);
   }


### PR DESCRIPTION
### refactor: simplificar serialização de GeoPoint e mover lógica para firestore.util

**Descrição:**
- Centraliza export do `GeoPoint` no `firebase.js` para evitar import direto do `firebase-admin` no repositório
- Remove `prepareLocationToReturn` do repositório — responsabilidade movida para `firestore.util` que já serializava `Timestamp`
- Remove checagens de tipo redundantes no `toGeoPoint` — o schema Zod já garante que `latitude` e `longitude` existem e são números válidos
- `parseLocation` no validator simplificado para apenas deserializar a string JSON, delegando a validação dos valores ao schema