### PR TITLE
refactor: migra parte do auth para o adminsdk no backend

### DIFF
--- a/src/modules/auth/auth.controller.js
+++ b/src/modules/auth/auth.controller.js
@@ -1,0 +1,15 @@
+import * as authService from "./auth.service.js";
+import { success } from "../../shared/utils/response.util.js";
+import { StatusCodes } from "http-status-codes";
+
+/** @type {import("express").RequestHandler} */
+export const register = async (req, res) => {
+  const user = await authService.register(req.validatedAuthData);
+  return success(res, user, StatusCodes.CREATED);
+};
+
+/** @type {import("express").RequestHandler} */
+export const checkUsername = async (req, res) => {
+  const result = await authService.checkUsername(req.params.username);
+  return success(res, result, StatusCodes.OK);
+};

--- a/src/modules/auth/auth.repository.js
+++ b/src/modules/auth/auth.repository.js
@@ -1,0 +1,26 @@
+import { db } from "../../config/firebase.js";
+import { env } from "../../config/env.js";
+
+const USERS_COLLECTION = `${env.firebase.collectionPrefix}users`;
+const USERNAMES_COLLECTION = `${env.firebase.collectionPrefix}usernames`;
+
+export async function checkUsernameExists(username) {
+  const doc = await db.collection(USERNAMES_COLLECTION).doc(username.toLowerCase()).get();
+  return doc.exists;
+}
+
+export async function createUserDocument(uid, userData) {
+  await db.collection(USERS_COLLECTION).doc(uid).set({
+    email: userData.email,
+    name: userData.name,
+    username: userData.username.toLowerCase(),
+    createdAt: new Date().toISOString(),
+  });
+}
+
+export async function createUsernameDocument(username, uid, email) {
+  await db.collection(USERNAMES_COLLECTION).doc(username.toLowerCase()).set({
+    email,
+    uid,
+  });
+}

--- a/src/modules/auth/auth.service.js
+++ b/src/modules/auth/auth.service.js
@@ -1,0 +1,74 @@
+import admin from "firebase-admin";
+import { AppError } from "../../shared/errors/app.error.js";
+import { StatusCodes } from "http-status-codes";
+import * as authRepository from "./auth.repository.js";
+import logger from "../../logger/index.js";
+
+export async function register(userData) {
+  const { email, password, name, username } = userData;
+
+  const usernameExists = await authRepository.checkUsernameExists(username);
+  if (usernameExists) {
+    throw new AppError(
+      "Este username já está em uso",
+      StatusCodes.CONFLICT,
+      "USERNAME_ALREADY_EXISTS",
+    );
+  }
+
+  try {
+    const userRecord = await admin.auth().createUser({
+      email,
+      password,
+      displayName: name,
+    });
+
+    await authRepository.createUserDocument(userRecord.uid, {
+      email,
+      name,
+      username,
+    });
+
+    await authRepository.createUsernameDocument(username, userRecord.uid, email);
+
+    const customToken = await admin.auth().createCustomToken(userRecord.uid);
+
+    logger.info({ uid: userRecord.uid, email }, "Usuário criado com sucesso");
+
+    return {
+      uid: userRecord.uid,
+      email: userRecord.email,
+      displayName: userRecord.displayName,
+      customToken,
+    };
+  } catch (error) {
+    logger.error({ error: error.message }, "Erro ao criar usuário");
+
+    if (error.code === "auth/email-already-exists") {
+      throw new AppError(
+        "Este email já está cadastrado",
+        StatusCodes.CONFLICT,
+        "EMAIL_ALREADY_IN_USE",
+      );
+    }
+
+    if (error.code === "auth/invalid-email") {
+      throw new AppError("Email inválido", StatusCodes.BAD_REQUEST, "INVALID_EMAIL");
+    }
+
+    if (error.code === "auth/weak-password") {
+      throw new AppError("Senha muito fraca", StatusCodes.BAD_REQUEST, "WEAK_PASSWORD");
+    }
+
+    throw new AppError(
+      "Erro ao criar conta",
+      StatusCodes.INTERNAL_SERVER_ERROR,
+      "REGISTRATION_FAILED",
+    );
+  }
+}
+
+export async function checkUsername(username) {
+  const exists = await authRepository.checkUsernameExists(username);
+  return { available: !exists };
+}

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import * as authController from "../modules/auth/auth.controller.js";
+import * as authValidator from "../validators/auth.validator.js";
+import { wrap } from "../shared/utils/async-handler.util.js";
+
+const router = Router();
+
+router.post("/register", authValidator.validateRegister, wrap(authController.register));
+
+router.get(
+  "/check-username/:username",
+  authValidator.validateCheckUsername,
+  wrap(authController.checkUsername),
+);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import complaintRoutes from "./complaints.routes.js";
+import authRoutes from "./auth.routes.js";
 import "../config/zod.config.js";
 
 const router = Router();
 
+router.use("/auth", authRoutes);
 router.use("/complaints", complaintRoutes);
 
 export default router;

--- a/src/schemas/auth.schema.js
+++ b/src/schemas/auth.schema.js
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const registerSchema = z.object({
+  body: z.object({
+    name: z
+      .string({ required_error: "Nome é obrigatório" })
+      .trim()
+      .min(2, "Nome deve ter pelo menos 2 caracteres"),
+
+    email: z
+      .string({ required_error: "Email é obrigatório" })
+      .trim()
+      .email("Email inválido"),
+
+    username: z
+      .string({ required_error: "Username é obrigatório" })
+      .trim()
+      .min(4, "Username deve ter pelo menos 4 caracteres")
+      .regex(/^[a-zA-Z0-9_]+$/, "Username pode conter apenas letras, números e _"),
+
+    password: z
+      .string({ required_error: "Senha é obrigatória" })
+      .min(8, "Senha deve ter pelo menos 8 caracteres")
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
+        "Senha deve conter letras maiúsculas, minúsculas e números",
+      ),
+  }),
+});
+
+export const checkUsernameSchema = z.object({
+  params: z.object({
+    username: z
+      .string({ required_error: "Username é obrigatório" })
+      .trim()
+      .min(1, "Username é obrigatório"),
+  }),
+});

--- a/src/validators/auth.validator.js
+++ b/src/validators/auth.validator.js
@@ -1,0 +1,32 @@
+import { registerSchema, checkUsernameSchema } from "../schemas/auth.schema.js";
+
+export const validateRegister = (req, res, next) => {
+  const result = registerSchema.safeParse({ body: req.body });
+
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Dados inválidos",
+      errors: result.error.errors.map((err) => ({
+        field: err.path[1],
+        message: err.message,
+      })),
+    });
+  }
+
+  req.validatedAuthData = result.data.body;
+  next();
+};
+
+export const validateCheckUsername = (req, res, next) => {
+  const result = checkUsernameSchema.safeParse({ params: req.params });
+
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Username inválido",
+    });
+  }
+
+  next();
+};


### PR DESCRIPTION
## Migra autenticação para backend usando Firebase Admin SDK

  **Alterações Backend (petsos-api)**:

  - Cria módulo auth com controller, service, repository
  - Adiciona endpoints POST /api/auth/register e GET /api/auth/check-username/:username
  - Implementa validações Zod (name, email, username, password)
  - Usa Firebase Admin SDK para criar usuário e documentos Firestore
  - Gera customToken para autenticação client-side
  - Traduz erros Firebase (EMAIL_ALREADY_IN_USE, USERNAME_ALREADY_EXISTS, etc)
  
  **Como funciona**:

  - Backend cria usuário via Admin SDK e retorna customToken (JWT válido 1h)
  - Frontend autentica automaticamente com token (sem pedir senha 2x)
  - Firebase SDK envia email verificação usando templates configurados
  - Validações duplicadas (frontend = UX, backend = segurança)
  - Senha trafega 1x apenas, customToken efêmero para autenticação inicial
  - Firestore Security Rules podem ser mais restritivas (só backend escreve users)
  
closes #80
closes #82  