### PR TITLE
feat: adiciona rota para assumir denúncias

### DIFF
--- a/src/modules/complaints/complaints.controller.js
+++ b/src/modules/complaints/complaints.controller.js
@@ -47,3 +47,13 @@ export const getNearest = async (req, res) => {
 
   return success(res, complaints, 200);
 };
+
+/** @type {import("express").RequestHandler} */
+export const assumeComplaint = async (req, res) => {
+  const complaint = await complaintService.assumeComplaint({
+    complaintId: req.params.id,
+    userId: req.userId,
+  });
+
+  return success(res, complaint, StatusCodes.CREATED);
+};

--- a/src/modules/complaints/complaints.service.js
+++ b/src/modules/complaints/complaints.service.js
@@ -3,6 +3,7 @@ import { COMPLAINT_STATUS } from "../../shared/types/complaint.status.js";
 import { deleteFiles } from "../../shared/helpers/file.helper.js";
 import { ValidationError } from "../../shared/errors/validation.error.js";
 import { ERROR_CODES } from "../../shared/types/error.codes.js";
+import * as complaintFollowersRepository from "../complaint-followers/complaint-followers.repository.js";
 
 export const create = async (complaintData) => {
   const complaint = {
@@ -66,4 +67,12 @@ export const findNearestWithinRadius = async ({ lat, lng, radiusKm }) => {
     parsedLng,
     parsedRadiusKm,
   );
+};
+
+export const assumeComplaint = async ({ complaintId, userId }) => {
+  await complaintFollowersRepository.follow(complaintId, userId);
+
+  return {
+    message: "Denúncia assumida com sucesso",
+  };
 };

--- a/src/routes/complaints.routes.js
+++ b/src/routes/complaints.routes.js
@@ -3,6 +3,7 @@ import * as complaintController from "../modules/complaints/complaints.controlle
 import { wrap } from "../shared/utils/async-handler.util.js";
 import { validateUploadImage } from "../validators/upload.validator.js";
 import { validateCreateComplaint, validateUpdateComplaint } from "../validators/complaint.validator.js";
+import { authenticateToken } from "../shared/middlewares/auth.middleware.js";
 
 const router = Router();
 
@@ -12,5 +13,8 @@ router.get("/nearest", wrap(complaintController.getNearest));
 router.get("/:id", wrap(complaintController.getDetail));
 router.patch("/:id", validateUploadImage, validateUpdateComplaint, wrap(complaintController.patchComplaint));
 router.delete("/:id", wrap(complaintController.deleteComplaint));
+router.post( "/:id/assumir", authenticateToken, wrap(complaintController.assumeComplaint)
+);
+
 
 export default router;


### PR DESCRIPTION
Implementa rota para assumir denúncias:

POST /api/complaints/:id/assumir

Funcionalidades:
- Requer autenticação
- Adiciona usuário como acompanhante da denúncia
- Retorna 201 Created
- Retorna 409 se usuário já acompanha

closes #63 