### PR TITLE
feat: implementa rota para assumir denúncia

### DIFF
--- a/src/modules/complaints/complaints.controller.js
+++ b/src/modules/complaints/complaints.controller.js
@@ -48,3 +48,9 @@ export const getNearest = async (req, res) => {
   const responseData = z.array(complaintResponseSchema).parse(complaints);
   return success(res, responseData, StatusCodes.OK);
 };
+
+/** @type {import("express").RequestHandler} */
+export const assumeComplaint = async (req, res) => {
+  const result = await complaintService.assumeComplaint(req.params.id, req.userId);
+  return success(res, result, StatusCodes.CREATED);
+};

--- a/src/modules/complaints/complaints.service.js
+++ b/src/modules/complaints/complaints.service.js
@@ -5,6 +5,7 @@ import { ForbiddenError } from "../../shared/errors/forbidden.error.js";
 import { NotFoundError } from "../../shared/errors/not-found.error.js";
 import * as complaintFollowersRepository from "../complaint-followers/complaint-followers.repository.js";
 import * as usersRepository from "../users/users.repository.js";
+import * as followerRepository from "../complaint-followers/complaint-followers.repository.js";
 
 const enrichWithCreator = async (complaints) => {
   if (complaints.length === 0) return [];
@@ -107,4 +108,12 @@ export const getAssumedByUsername = async (username) => {
   if (complaintIds.length === 0) return [];
 
   return await complaintRepository.getByIds(complaintIds);
+};
+
+export const assumeComplaint = async (complaintId, userId) => {
+  await followerRepository.follow(complaintId, userId);
+
+  return {
+    message: "Denúncia assumida com sucesso",
+  };
 };

--- a/src/modules/users/users.repository.js
+++ b/src/modules/users/users.repository.js
@@ -70,18 +70,15 @@ export async function getUserProfilesByIds(userIds) {
   if (!userIds?.length) return [];
 
   const uniqueUserIds = [...new Set(userIds)];
-  const users = [];
 
-  for (const userId of uniqueUserIds) {
-    const doc = await db.collection(USERS_COLLECTION).doc(userId).get();
+  const refs = uniqueUserIds.map((userId) => db.collection(USERS_COLLECTION).doc(userId));
 
-    if (doc.exists) {
-      users.push({
-        id: doc.id,
-        ...doc.data(),
-      });
-    }
-  }
+  const snapshots = await db.getAll(...refs);
 
-  return users;
+  return snapshots
+    .filter((doc) => doc.exists)
+    .map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
 }

--- a/src/routes/complaints.routes.js
+++ b/src/routes/complaints.routes.js
@@ -45,4 +45,9 @@ router.delete(
   wrap(complaintController.deleteComplaint)
 );
 
+router.post(
+  "/:id/assumir",
+  authenticateToken,
+  wrap(complaintController.assumeComplaint)
+);
 export default router;


### PR DESCRIPTION
## O que foi feito

* Adicionada rota `POST /complaints/:id/assumir`
* Protegida rota com autenticação JWT
* Implementado `assumeComplaint` no controller
* Implementado fluxo no `complaints.service.js`
* Integrado com `complaint-followers.repository`
* Retorno de erro `409` quando usuário já acompanha denúncia
* Retorno `201` quando acompanhamento criado com sucesso

## Testes realizados

* Testado via Postman
* Testado integração pelo app
* Validado retorno de conflito ao assumir denúncia já acompanhada

closes #63 