### PR TITLE
fix: restaura rota de assumir denúncia

### DIFF
--- a/src/modules/complaint-followers/complaint-followers.controller.js
+++ b/src/modules/complaint-followers/complaint-followers.controller.js
@@ -41,3 +41,13 @@ export const isFollowing = async (req, res) => {
 
   return success(res, result, StatusCodes.OK);
 };
+
+/** @type {import("express").RequestHandler} */
+export const followByParam = async (req, res) => {
+  const result = await complaintFollowersService.follow({
+    complaintId: req.params.complaintId,
+    userId: req.userId,
+  });
+
+  return success(res, result, StatusCodes.CREATED);
+};

--- a/src/routes/complaint-followers.routes.js
+++ b/src/routes/complaint-followers.routes.js
@@ -16,6 +16,12 @@ router.post(
   wrap(complaintFollowersController.follow),
 );
 
+router.post(
+  "/:complaintId/assumir",
+  authenticateToken,
+  complaintFollowersController.followByParam,
+);
+
 router.get(
   "/:complaintId/me",
   authenticateToken,


### PR DESCRIPTION
Alterações
adiciona rota /complaint-followers/:complaintId/assumir
adiciona controller followByParam
ajusta front para nova rota
mantém compatibilidade com fluxo anterior de assumir denúncia
corrige mudança de estado do botão “Assumir/Acompanhando”
Testes realizados
POST funcionando via Postman
alteração de estado do botão funcionando

closes #112 