### PR TITLE
feat: add grouped comment notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "geofire-common": "^6.0.0",
     "http-status-codes": "^2.3.0",
     "multer": "^2.1.1",
+    "node-cron": "^4.2.1",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
     "zod": "^4.3.6"

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ import routes from "./src/routes/index.js";
 import { errorHandler } from "./src/shared/middlewares/error.middleware.js";
 import { httpLogger } from "./src/config/pino-http.config.js";
 import logger from "./src/logger/index.js";
+import { startNotificationGrouperJob } from "./src/jobs/notification-grouper.job.js";
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -21,6 +22,7 @@ app.use(errorHandler);
 
 const server = app.listen(PORT, () => {
   logger.info(`Servidor rodando na porta ${PORT}`);
+  startNotificationGrouperJob();
 });
 
 server.on("error", (error) => {

--- a/src/jobs/notification-grouper.job.js
+++ b/src/jobs/notification-grouper.job.js
@@ -1,0 +1,48 @@
+import cron from "node-cron";
+
+import * as notificationsRepository from "../modules/notifications/notifications.repository.js";
+import * as notificationsService from "../modules/notifications/notifications.service.js";
+
+/**
+ * Agrupa notificações de comentários
+ * a cada 15 minutos.
+ */
+export const startNotificationGrouperJob = () => {
+  cron.schedule("*/15 * * * *", async () => {
+    const notifications =
+      await notificationsRepository.findUngroupedCommentNotifications();
+
+    const groups = {};
+
+    for (const notification of notifications) {
+      const key = `${notification.userId}_${notification.complaintId}`;
+
+      if (!groups[key]) {
+        groups[key] = [];
+      }
+
+      groups[key].push(notification);
+    }
+
+    for (const group of Object.values(groups)) {
+      if (group.length <= 1) {
+        continue;
+      }
+
+      const firstNotification = group[0];
+
+      await notificationsService.createNotification({
+        userId: firstNotification.userId,
+        complaintId: firstNotification.complaintId,
+        type: "comment_group",
+        message: `${group.length} novos comentários em uma denúncia que você acompanha.`,
+        sendPush: true,
+        count: group.length,
+      });
+
+      await notificationsRepository.markAsGrouped(
+        group.map((notification) => notification.id),
+      );
+    }
+  });
+};

--- a/src/modules/comments/comments.service.js
+++ b/src/modules/comments/comments.service.js
@@ -1,11 +1,20 @@
 import * as commentsRepository from "./comments.repository.js";
 import * as usersService from "../users/users.service.js";
+import * as notificationsService from "../notifications/notifications.service.js";
 
 export const create = async ({ complaintId, userId, text }) => {
   const comment = await commentsRepository.create({
     complaintId,
     userId,
     text,
+  });
+
+  await notificationsService.notifyComplaintFollowers({
+    complaintId,
+    actorUserId: userId,
+    type: "new_comment",
+    message: "Novo comentário em uma denúncia que você acompanha.",
+    sendPush: false,
   });
 
   return await usersService.enrichWithUsername(comment);

--- a/src/modules/complaints/complaints.service.js
+++ b/src/modules/complaints/complaints.service.js
@@ -5,6 +5,7 @@ import { ForbiddenError } from "../../shared/errors/forbidden.error.js";
 import { NotFoundError } from "../../shared/errors/not-found.error.js";
 import * as complaintFollowersRepository from "../complaint-followers/complaint-followers.repository.js";
 import * as usersService from "../users/users.service.js";
+import * as notificationsService from "../notifications/notifications.service.js";
 
 export const create = async (complaintData, authenticatedUserId) => {
   const complaintId = complaintRepository.createId();
@@ -56,6 +57,14 @@ export const patch = async (id, body, authenticatedUserId) => {
   };
 
   const updated = await complaintRepository.patch(id, updatedData);
+
+  await notificationsService.notifyComplaintFollowers({
+    complaintId: id,
+    actorUserId: authenticatedUserId,
+    type: "complaint_update",
+    message: "Uma denúncia que você acompanha foi atualizada.",
+    sendPush: true,
+  });
   return await usersService.enrichWithCreatedByUsername(updated);
 };
 

--- a/src/modules/notifications/notifications.repository.js
+++ b/src/modules/notifications/notifications.repository.js
@@ -10,15 +10,22 @@ const COLLECTION = `${env.firebase.collectionPrefix}notifications`;
 /**
  * Cria uma nova notificação no Firestore.
  */
-export const create = async ({ userId, complaintId, type, message }) => {
+export const create = async ({
+  userId,
+  complaintId,
+  type,
+  message,
+  count = 1,
+  grouped = false,
+}) => {
   const notificationData = {
     userId,
     complaintId,
     type,
     message,
     read: false,
-    grouped: false,
-    count: 1,
+    grouped,
+    count,
     createdAt: new Date(),
   };
 
@@ -127,4 +134,22 @@ export const markAsGrouped = async (notificationIds) => {
   });
 
   await batch.commit();
+};
+
+/**
+ * Busca notificações de comentários não agrupadas
+ * para o job de agrupamento.
+ */
+export const findUngroupedCommentNotifications = async () => {
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("type", "==", "new_comment")
+    .where("grouped", "==", false)
+    .where("read", "==", false)
+    .get();
+
+  return snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+  }));
 };

--- a/src/modules/notifications/notifications.service.js
+++ b/src/modules/notifications/notifications.service.js
@@ -3,6 +3,7 @@ import { env } from "../../config/env.js";
 
 import * as notificationsRepository from "./notifications.repository.js";
 import * as usersRepository from "../users/users.repository.js";
+import * as complaintFollowersRepository from "../complaint-followers/complaint-followers.repository.js";
 
 const USERS_COLLECTION = `${env.firebase.collectionPrefix}users`;
 
@@ -15,6 +16,8 @@ export const createNotification = async ({
   type,
   message,
   sendPush = true,
+  count = 1,
+  grouped = false,
 }) => {
   const userDoc = await db.collection(USERS_COLLECTION).doc(userId).get();
 
@@ -46,6 +49,8 @@ export const createNotification = async ({
     complaintId,
     type,
     message,
+    count,
+    grouped,
   });
 
   return {
@@ -91,4 +96,34 @@ export const countUnread = async (userId) => {
   return {
     count,
   };
+};
+
+/**
+ * Notifica os seguidores de uma denúncia,
+ * exceto o usuário que executou a ação.
+ */
+export const notifyComplaintFollowers = async ({
+  complaintId,
+  actorUserId,
+  type,
+  message,
+  sendPush = false,
+}) => {
+  const followerIds = await complaintFollowersRepository.getFollowers(complaintId);
+
+  const followersToNotify = followerIds.filter(
+    (followerId) => followerId !== actorUserId,
+  );
+
+  return await Promise.all(
+    followersToNotify.map((followerId) =>
+      createNotification({
+        userId: followerId,
+        complaintId,
+        type,
+        message,
+        sendPush,
+      }),
+    ),
+  );
 };


### PR DESCRIPTION
## O que foi feito

- Adicionada notificação para seguidores quando uma denúncia é atualizada
- Adicionada notificação interna ao criar novo comentário em denúncia acompanhada
- Comentários criam notificação com `sendPush: false`
- Instalado `node-cron`
- Criado job `notification-grouper.job.js`
- Implementado agrupamento de notificações de comentários por `userId + complaintId`
- Criada notificação agrupada com contador correto
- Notificações originais são marcadas como `grouped: true`
- Job registrado no `server.js`

## Testes realizados

- Testado no Postman criação de comentário em denúncia acompanhada
- Validado retorno de notificação `new_comment`
- Validado agrupamento em `comment_group`
- Validado `count: 3` na notificação agrupada
- Validado atualização de denúncia gerando `complaint_update`

## Critérios atendidos

- Atualização de denúncia notifica seguidores imediatamente
- Comentários não enviam push imediato
- Job agrupa múltiplos comentários em 1 notificação
- Notificações agrupadas mostram contador correto

closes #76 