### PR TITLE
Feature/public users follow count

### DIFF
--- a/src/modules/users/users.controller.js
+++ b/src/modules/users/users.controller.js
@@ -1,14 +1,32 @@
 import * as complaintService from "../complaints/complaints.service.js";
+import * as usersService from "./users.service.js";
 import { success } from "../../shared/utils/response.util.js";
 import { StatusCodes } from "http-status-codes";
 import { z } from "zod";
-import { complaintResponseSchema } from "../../schemas/complaint.schema.js";
+import { publicComplaintSummarySchema } from "../../schemas/complaint.schema.js";
+import { publicUserProfileSchema } from "../../schemas/user.schema.js";
+
+/** @type {import("express").RequestHandler} */
+export const getMe = async (req, res) => {
+  const profile = await usersService.getPublicProfileById(req.userId);
+  const responseData = publicUserProfileSchema.parse(profile);
+  return success(res, responseData, StatusCodes.OK);
+};
+
+/** @type {import("express").RequestHandler} */
+export const getPublicProfile = async (req, res) => {
+  const profile = await usersService.getPublicProfileByUsername(
+    req.validatedParams.username,
+  );
+  const responseData = publicUserProfileSchema.parse(profile);
+  return success(res, responseData, StatusCodes.OK);
+};
 
 /** @type {import("express").RequestHandler} */
 export const getFollowedComplaints = async (req, res) => {
   const complaints = await complaintService.getFollowedByUsername(
     req.validatedParams.username,
   );
-  const responseData = z.array(complaintResponseSchema).parse(complaints);
+  const responseData = z.array(publicComplaintSummarySchema).parse(complaints);
   return success(res, responseData, StatusCodes.OK);
 };

--- a/src/modules/users/users.repository.js
+++ b/src/modules/users/users.repository.js
@@ -16,6 +16,20 @@ export async function getUsernameByUid(uid) {
   return doc.exists ? (doc.data().username ?? null) : null;
 }
 
+export async function getUserById(uid) {
+  const doc = await db.collection(USERS_COLLECTION).doc(uid).get();
+
+  return doc.exists ? doc.data() : null;
+}
+
+export async function getUserByUsername(username) {
+  const uid = await getUidByUsername(username);
+
+  if (!uid) return null;
+
+  return await getUserById(uid);
+}
+
 /**
  * Retorna um Map<uid, username>.
  */

--- a/src/modules/users/users.service.js
+++ b/src/modules/users/users.service.js
@@ -1,7 +1,34 @@
 import * as usersRepository from "./users.repository.js";
+import { NotFoundError } from "../../shared/errors/not-found.error.js";
+
+const toPublicProfile = (profile) => ({
+  name: profile.name ?? null,
+  username: profile.username,
+  createdAt: profile.createdAt,
+});
 
 export const getUidByUsername = async (username) => {
   return await usersRepository.getUidByUsername(username);
+};
+
+export const getPublicProfileByUsername = async (username) => {
+  const profile = await usersRepository.getUserByUsername(username);
+
+  if (!profile) {
+    throw new NotFoundError();
+  }
+
+  return toPublicProfile(profile);
+};
+
+export const getPublicProfileById = async (userId) => {
+  const profile = await usersRepository.getUserById(userId);
+
+  if (!profile) {
+    throw new NotFoundError();
+  }
+
+  return toPublicProfile(profile);
 };
 
 export const getUsernamesByIds = async (uids) => {

--- a/src/routes/complaint-followers.routes.js
+++ b/src/routes/complaint-followers.routes.js
@@ -29,7 +29,6 @@ router.delete(
 
 router.get(
   "/:complaintId/count",
-  authenticateToken,
   validateComplaintIdParam,
   wrap(complaintFollowersController.count),
 );

--- a/src/routes/users.routes.js
+++ b/src/routes/users.routes.js
@@ -2,13 +2,18 @@ import { Router } from "express";
 import * as usersController from "../modules/users/users.controller.js";
 import { wrap } from "../shared/utils/async-handler.util.js";
 import { validateUsernameParam } from "../validators/auth.validator.js";
+import { authenticateToken } from "../shared/middlewares/auth.middleware.js";
 
 const router = Router();
+
+router.get("/me", authenticateToken, wrap(usersController.getMe));
 
 router.get(
   "/:username/followed-complaints",
   validateUsernameParam,
   wrap(usersController.getFollowedComplaints),
 );
+
+router.get("/:username", validateUsernameParam, wrap(usersController.getPublicProfile));
 
 export default router;

--- a/src/schemas/complaint.schema.js
+++ b/src/schemas/complaint.schema.js
@@ -52,3 +52,11 @@ export const complaintResponseSchema = complaintBaseSchema.extend({
   createdById: z.string().optional(),
   createdByUsername: z.string().nullable().optional(),
 });
+
+export const publicComplaintSummarySchema = complaintBaseSchema.extend({
+  id: z.string(),
+  status: z.enum(VALID_COMPLAINT_STATUS),
+  followersCount: z.number().default(0),
+  createdAt: z.any().optional(),
+  updatedAt: z.any().optional(),
+});

--- a/src/schemas/user.schema.js
+++ b/src/schemas/user.schema.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const publicUserProfileSchema = z.object({
+  name: z.string().nullable().optional(),
+  username: z.string(),
+  createdAt: z.any().optional(),
+});


### PR DESCRIPTION
### Descrição da branch:

Essa branch adiciona suporte ao perfil público por `username` e mantém o fluxo sem expor `uid` para o frontend. O frontend consegue buscar dados públicos do usuário e as denúncias acompanhadas por ele, enquanto dados sensíveis continuam fora da resposta.

Também ajusta a rota de contagem de acompanhantes para ser pública, porque o detalhe da denúncia precisa mostrar apenas o número de pessoas acompanhando. As demais rotas protegidas continuam protegidas: comentários, replies, lista de acompanhantes, estado `isFollowing`, follow/unfollow e ações de denúncia.

### Commits:

#### 1. `feat(users): adicionar perfil público por username`

**Motivo:** permitir abrir perfis públicos sem trafegar id sensível de usuário entre frontend e backend.

**Arquivos:**
- `src/routes/users.routes.js`
- `src/modules/users/users.controller.js`
- `src/modules/users/users.service.js`
- `src/modules/users/users.repository.js`
- `src/schemas/user.schema.js`

#### 2. `feat(users): listar denúncias acompanhadas por username`

**Motivo:** a tela de perfil precisa mostrar as denúncias que o usuário acompanha em formato suficiente para cards, sem expor dados internos de usuário.

**Arquivos:**
- `src/modules/complaints/complaints.service.js`
- `src/schemas/complaint.schema.js`

#### 3. `fix(followers): liberar apenas contagem pública`

**Motivo:** visitante pode ver quantas pessoas acompanham uma denúncia, mas não pode ver a lista de usuários nem o estado de follow.

**Arquivos:**
- `src/routes/complaint-followers.routes.js`