### PR TITLE
feat: módulos de evidências e votação de denúncias

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,20 @@
 {
   "indexes": [
     {
+      "collectionGroup": "dev_complaint_evidence",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "complaintId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "dev_complaint_followers",
       "queryScope": "COLLECTION",
       "fields": [

--- a/src/modules/complaint-evidence/complaint-evidence.controller.js
+++ b/src/modules/complaint-evidence/complaint-evidence.controller.js
@@ -1,0 +1,34 @@
+import { StatusCodes } from "http-status-codes";
+import * as complaintEvidenceService from "./complaint-evidence.service.js";
+import { success } from "../../shared/utils/response.util.js";
+
+export const submitEvidence = async (req, res) => {
+  const photos = req.files?.map((file) => `/uploads/${file.filename}`) ?? [];
+
+  const result = await complaintEvidenceService.submitEvidence(
+    req.params.id,
+    req.userId,
+    {
+      description: req.body.description,
+      photos,
+    },
+  );
+
+  return success(res, result, StatusCodes.CREATED);
+};
+
+export const getByComplaintId = async (req, res) => {
+  const result = await complaintEvidenceService.getByComplaintId(req.params.id);
+
+  return success(res, result, StatusCodes.OK);
+};
+
+export const validateEvidence = async (req, res) => {
+  const result = await complaintEvidenceService.validateEvidence(
+    req.params.id,
+    req.userId,
+    { approved: req.body.approved, evidenceIds: req.body.evidenceIds },
+  );
+
+  return success(res, result, StatusCodes.OK);
+};

--- a/src/modules/complaint-evidence/complaint-evidence.repository.js
+++ b/src/modules/complaint-evidence/complaint-evidence.repository.js
@@ -1,0 +1,74 @@
+import { db } from "../../config/firebase.js";
+import { env } from "../../config/env.js";
+import { NotFoundError } from "../../shared/errors/not-found.error.js";
+import { ERROR_CODES } from "../../shared/types/error.codes.js";
+import { serialize } from "../../shared/utils/firestore.util.js";
+
+const COLLECTION = `${env.firebase.collectionPrefix}complaint_evidence`;
+const COMPLAINTS_COLLECTION = `${env.firebase.collectionPrefix}complaints`;
+
+export const create = async (complaintId, evidenceData) => {
+  const complaintRef = db.collection(COMPLAINTS_COLLECTION).doc(complaintId);
+  const complaintDoc = await complaintRef.get();
+
+  if (!complaintDoc.exists) {
+    throw new NotFoundError(ERROR_CODES.COMPLAINT_NOT_FOUND);
+  }
+
+  const docRef = db.collection(COLLECTION).doc();
+
+  const evidence = {
+    complaintId,
+    ...evidenceData,
+    createdAt: new Date(),
+  };
+
+  await docRef.set(evidence);
+
+  return serialize(docRef.id, evidence);
+};
+
+export const getByComplaintId = async (complaintId) => {
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("complaintId", "==", complaintId)
+    .get();
+
+  const results = snapshot.docs.map((doc) => serialize(doc.id, doc.data()));
+  return results.sort((a, b) => {
+    const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return dateB - dateA;
+  });
+};
+
+export const exists = async (complaintId) => {
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("complaintId", "==", complaintId)
+    .limit(1)
+    .get();
+
+  return !snapshot.empty;
+};
+
+export const updateStatusByIds = async (evidenceIds, status) => {
+  const batch = db.batch();
+  for (const id of evidenceIds) {
+    batch.update(db.collection(COLLECTION).doc(id), { status });
+  }
+  await batch.commit();
+};
+
+export const rejectAllByComplaintId = async (complaintId) => {
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("complaintId", "==", complaintId)
+    .get();
+
+  const batch = db.batch();
+  snapshot.docs.forEach((doc) => {
+    batch.update(doc.ref, { status: "rejected" });
+  });
+  await batch.commit();
+};

--- a/src/modules/complaint-evidence/complaint-evidence.service.js
+++ b/src/modules/complaint-evidence/complaint-evidence.service.js
@@ -1,0 +1,125 @@
+import * as complaintEvidenceRepository from "./complaint-evidence.repository.js";
+import * as complaintRepository from "../complaints/complaints.repository.js";
+import * as complaintVolunteersRepository from "../complaint-volunteers/complaint-volunteers.repository.js";
+import * as usersService from "../users/users.service.js";
+import * as notificationsService from "../notifications/notifications.service.js";
+import { COMPLAINT_STATUS } from "../../shared/types/complaint.status.js";
+import { ForbiddenError } from "../../shared/errors/forbidden.error.js";
+import { ValidationError } from "../../shared/errors/validation.error.js";
+import { ERROR_CODES } from "../../shared/types/error.codes.js";
+
+export const submitEvidence = async (complaintId, userId, { description, photos }) => {
+  const complaint = await complaintRepository.getDetail(complaintId);
+
+  const isVolunteer = await complaintVolunteersRepository.isVolunteer(
+    complaintId,
+    userId,
+  );
+  if (!isVolunteer) {
+    throw new ForbiddenError("Apenas voluntários podem enviar evidências");
+  }
+
+  if (complaint.status !== COMPLAINT_STATUS.IN_PROGRESS) {
+    throw new ValidationError(
+      "Apenas denúncias em andamento aceitam evidências",
+      ERROR_CODES.COMPLAINT_INVALID_STATUS_TRANSITION,
+    );
+  }
+
+  const evidence = await complaintEvidenceRepository.create(complaintId, {
+    userId,
+    description,
+    photos,
+  });
+
+  await complaintRepository.setStatus(complaintId, COMPLAINT_STATUS.AWAITING_VALIDATION);
+
+  await notificationsService.notifyComplaintFollowers({
+    complaintId,
+    actorUserId: userId,
+    type: "status_change",
+    message: `Evidência enviada para a denúncia "${complaint.title}". Aguardando validação.`,
+    sendPush: false,
+  });
+
+  return evidence;
+};
+
+export const getByComplaintId = async (complaintId) => {
+  const evidences = await complaintEvidenceRepository.getByComplaintId(complaintId);
+
+  const userIds = [...new Set(evidences.map((e) => e.userId))];
+  const usersById = await usersService.getUsernamesByIds(userIds);
+
+  return evidences.map((evidence) => ({
+    ...evidence,
+    username: usersById.get(evidence.userId) || null,
+  }));
+};
+
+export const exists = async (complaintId) => {
+  return await complaintEvidenceRepository.exists(complaintId);
+};
+
+export const validateEvidence = async (
+  complaintId,
+  userId,
+  { approved, evidenceIds },
+) => {
+  const complaint = await complaintRepository.getDetail(complaintId);
+
+  if (complaint.createdById !== userId) {
+    throw new ForbiddenError("Apenas o criador da denúncia pode validar evidências");
+  }
+
+  if (complaint.status !== COMPLAINT_STATUS.AWAITING_VALIDATION) {
+    throw new ValidationError(
+      "Apenas denúncias aguardando validação podem ser validadas",
+      ERROR_CODES.COMPLAINT_INVALID_STATUS_TRANSITION,
+    );
+  }
+
+  if (!evidenceIds || evidenceIds.length === 0) {
+    throw new ValidationError("Selecione ao menos uma evidência para validar");
+  }
+
+  if (approved) {
+    await complaintEvidenceRepository.updateStatusByIds(evidenceIds, "approved");
+    await complaintRepository.setStatus(complaintId, COMPLAINT_STATUS.RESOLVED);
+
+    await notificationsService.notifyComplaintFollowers({
+      complaintId,
+      actorUserId: userId,
+      type: "status_change",
+      message: `A denúncia "${complaint.title}" foi marcada como resolvida.`,
+      sendPush: false,
+    });
+
+    return { message: "Evidências aprovadas. Denúncia resolvida.", resolved: true };
+  }
+
+  await complaintEvidenceRepository.updateStatusByIds(evidenceIds, "rejected");
+
+  const remaining = await complaintEvidenceRepository.getByComplaintId(complaintId);
+  const hasPending = remaining.some((e) => !e.status || e.status === "pending");
+
+  if (!hasPending) {
+    await complaintRepository.setStatus(complaintId, COMPLAINT_STATUS.IN_PROGRESS);
+
+    await notificationsService.notifyComplaintFollowers({
+      complaintId,
+      actorUserId: userId,
+      type: "status_change",
+      message: `A evidência da denúncia "${complaint.title}" foi rejeitada. Denúncia voltou para em andamento.`,
+      sendPush: false,
+    });
+  }
+
+  return {
+    message: hasPending
+      ? "Evidências rejeitadas. Ainda há evidências pendentes."
+      : "Evidências rejeitadas. Denúncia voltou para em andamento.",
+    resolved: false,
+    hasPending,
+  };
+};

--- a/src/modules/complaint-votes/complaint-votes.controller.js
+++ b/src/modules/complaint-votes/complaint-votes.controller.js
@@ -1,0 +1,19 @@
+import { StatusCodes } from "http-status-codes";
+import * as complaintVotesService from "./complaint-votes.service.js";
+import { success } from "../../shared/utils/response.util.js";
+
+export const vote = async (req, res) => {
+  const result = await complaintVotesService.vote({
+    complaintId: req.params.id,
+    userId: req.userId,
+    approved: req.body.approved,
+  });
+
+  return success(res, result, StatusCodes.CREATED);
+};
+
+export const getStatus = async (req, res) => {
+  const result = await complaintVotesService.getStatus(req.params.id, req.userId || null);
+
+  return success(res, result, StatusCodes.OK);
+};

--- a/src/modules/complaint-votes/complaint-votes.repository.js
+++ b/src/modules/complaint-votes/complaint-votes.repository.js
@@ -1,0 +1,57 @@
+import { db } from "../../config/firebase.js";
+import { env } from "../../config/env.js";
+import { ConflictError } from "../../shared/errors/conflict.error.js";
+import { NotFoundError } from "../../shared/errors/not-found.error.js";
+import { ERROR_CODES } from "../../shared/types/error.codes.js";
+
+const COLLECTION = `${env.firebase.collectionPrefix}complaint_votes`;
+const COMPLAINTS_COLLECTION = `${env.firebase.collectionPrefix}complaints`;
+
+const makeDocId = (complaintId, userId) => `${complaintId}_${userId}`;
+
+export const vote = async (complaintId, userId, approved) => {
+  const complaintRef = db.collection(COMPLAINTS_COLLECTION).doc(complaintId);
+  const complaintDoc = await complaintRef.get();
+
+  if (!complaintDoc.exists) {
+    throw new NotFoundError(ERROR_CODES.COMPLAINT_NOT_FOUND);
+  }
+
+  const docId = makeDocId(complaintId, userId);
+  const docRef = db.collection(COLLECTION).doc(docId);
+  const existing = await docRef.get();
+
+  if (existing.exists) {
+    throw new ConflictError("Você já votou nesta denúncia");
+  }
+
+  await docRef.set({
+    complaintId,
+    userId,
+    approved,
+    createdAt: new Date(),
+  });
+};
+
+export const getVotesByComplaintId = async (complaintId) => {
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("complaintId", "==", complaintId)
+    .get();
+
+  return snapshot.docs.map((doc) => doc.data());
+};
+
+export const countByComplaintId = async (complaintId) => {
+  const votes = await getVotesByComplaintId(complaintId);
+  const approved = votes.filter((v) => v.approved).length;
+  const rejected = votes.filter((v) => !v.approved).length;
+
+  return { approved, rejected, total: votes.length };
+};
+
+export const hasVoted = async (complaintId, userId) => {
+  const docId = makeDocId(complaintId, userId);
+  const doc = await db.collection(COLLECTION).doc(docId).get();
+  return doc.exists;
+};

--- a/src/modules/complaint-votes/complaint-votes.service.js
+++ b/src/modules/complaint-votes/complaint-votes.service.js
@@ -1,0 +1,118 @@
+import * as complaintVotesRepository from "./complaint-votes.repository.js";
+import * as complaintRepository from "../complaints/complaints.repository.js";
+import * as complaintFollowersRepository from "../complaint-followers/complaint-followers.repository.js";
+import * as complaintVolunteersRepository from "../complaint-volunteers/complaint-volunteers.repository.js";
+import * as notificationsService from "../notifications/notifications.service.js";
+import { COMPLAINT_STATUS } from "../../shared/types/complaint.status.js";
+import { ForbiddenError } from "../../shared/errors/forbidden.error.js";
+import { ValidationError } from "../../shared/errors/validation.error.js";
+import { ERROR_CODES } from "../../shared/types/error.codes.js";
+
+const VOTE_THRESHOLD_PERCENTAGE = 0.5;
+const OWNER_RESPONSE_DAYS = 7;
+
+const isOwnerInactive = (complaint) => {
+  const statusUpdatedAt =
+    complaint.statusUpdatedAt?.toDate?.() ?? complaint.statusUpdatedAt ?? null;
+
+  if (!statusUpdatedAt) return false;
+
+  const daysSinceUpdate =
+    (Date.now() - new Date(statusUpdatedAt).getTime()) / (1000 * 60 * 60 * 24);
+  return daysSinceUpdate >= OWNER_RESPONSE_DAYS;
+};
+
+export const vote = async ({ complaintId, userId, approved }) => {
+  const complaint = await complaintRepository.getDetail(complaintId);
+
+  if (complaint.status !== COMPLAINT_STATUS.AWAITING_VALIDATION) {
+    throw new ValidationError(
+      "Votação só é permitida em denúncias aguardando validação",
+      ERROR_CODES.COMPLAINT_INVALID_STATUS_TRANSITION,
+    );
+  }
+
+  if (complaint.createdById === userId) {
+    throw new ForbiddenError(
+      "O criador da denúncia deve usar a validação direta, não a votação",
+    );
+  }
+
+  if (!isOwnerInactive(complaint)) {
+    throw new ValidationError(
+      `Votação só é liberada após ${OWNER_RESPONSE_DAYS} dias sem resposta do criador`,
+      ERROR_CODES.COMPLAINT_VALIDATION,
+    );
+  }
+
+  const isFollower = await complaintFollowersRepository.isFollowing(complaintId, userId);
+  const isVolunteer = await complaintVolunteersRepository.isVolunteer(
+    complaintId,
+    userId,
+  );
+
+  if (!isFollower && !isVolunteer) {
+    throw new ForbiddenError("Apenas seguidores ou voluntários podem votar");
+  }
+
+  await complaintVotesRepository.vote(complaintId, userId, approved);
+
+  const followerIds = await complaintFollowersRepository.getFollowers(complaintId);
+  const volunteerIds = await complaintVolunteersRepository.getVolunteers(complaintId);
+  const eligibleVoters = new Set([...followerIds, ...volunteerIds]);
+  eligibleVoters.delete(complaint.createdById);
+  const totalEligible = eligibleVoters.size;
+
+  const counts = await complaintVotesRepository.countByComplaintId(complaintId);
+  const approvalThreshold = Math.ceil(totalEligible * VOTE_THRESHOLD_PERCENTAGE);
+
+  if (counts.approved >= approvalThreshold) {
+    await complaintRepository.setStatus(complaintId, COMPLAINT_STATUS.RESOLVED);
+
+    await notificationsService.notifyComplaintFollowers({
+      complaintId,
+      actorUserId: userId,
+      type: "status_change",
+      message: `A denúncia "${complaint.title}" foi resolvida por votação da comunidade.`,
+      sendPush: false,
+    });
+
+    return {
+      message: "Voto registrado. Denúncia resolvida por votação da comunidade.",
+      resolved: true,
+    };
+  }
+
+  return {
+    message: "Voto registrado com sucesso",
+    resolved: false,
+    votes: counts,
+    threshold: approvalThreshold,
+  };
+};
+
+export const getStatus = async (complaintId, userId) => {
+  const complaint = await complaintRepository.getDetail(complaintId);
+  const counts = await complaintVotesRepository.countByComplaintId(complaintId);
+  const hasVoted = userId
+    ? await complaintVotesRepository.hasVoted(complaintId, userId)
+    : false;
+
+  const followerIds = await complaintFollowersRepository.getFollowers(complaintId);
+  const volunteerIds = await complaintVolunteersRepository.getVolunteers(complaintId);
+  const eligibleVoters = new Set([...followerIds, ...volunteerIds]);
+  eligibleVoters.delete(complaint.createdById);
+
+  const votingEnabled =
+    complaint.status === COMPLAINT_STATUS.AWAITING_VALIDATION &&
+    isOwnerInactive(complaint);
+
+  return {
+    complaintId,
+    votingEnabled,
+    hasVoted,
+    votes: counts,
+    threshold: Math.ceil(eligibleVoters.size * VOTE_THRESHOLD_PERCENTAGE),
+    totalEligible: eligibleVoters.size,
+  };
+};

--- a/src/routes/complaints.routes.js
+++ b/src/routes/complaints.routes.js
@@ -1,5 +1,7 @@
 import { Router } from "express";
 import * as complaintController from "../modules/complaints/complaints.controller.js";
+import * as complaintEvidenceController from "../modules/complaint-evidence/complaint-evidence.controller.js";
+import * as complaintVotesController from "../modules/complaint-votes/complaint-votes.controller.js";
 import commentsRoutes from "./comments.routes.js";
 import { wrap } from "../shared/utils/async-handler.util.js";
 import { validateUploadImage } from "../validators/upload.validator.js";
@@ -9,6 +11,8 @@ import {
   validateUpdateStatus,
   validateNearestQuery,
 } from "../validators/complaint.validator.js";
+import { validateSubmitEvidence } from "../validators/complaint-evidence.validator.js";
+import { validateVote } from "../validators/complaint-votes.validator.js";
 import { authenticateToken } from "../shared/middlewares/auth.middleware.js";
 
 const router = Router();
@@ -26,6 +30,35 @@ router.get("/", wrap(complaintController.getAll));
 router.get("/nearest", validateNearestQuery, wrap(complaintController.getNearest));
 
 router.use("/:id/comments", commentsRoutes);
+
+router.post(
+  "/:id/evidences",
+  authenticateToken,
+  validateUploadImage,
+  validateSubmitEvidence,
+  wrap(complaintEvidenceController.submitEvidence),
+);
+
+router.get("/:id/evidences", wrap(complaintEvidenceController.getByComplaintId));
+
+router.post(
+  "/:id/evidences/validate",
+  authenticateToken,
+  wrap(complaintEvidenceController.validateEvidence),
+);
+
+router.post(
+  "/:id/votes",
+  authenticateToken,
+  validateVote,
+  wrap(complaintVotesController.vote),
+);
+
+router.get(
+  "/:id/votes/status",
+  authenticateToken,
+  wrap(complaintVotesController.getStatus),
+);
 
 router.get("/:id", wrap(complaintController.getDetail));
 

--- a/src/schemas/complaint-evidence.schema.js
+++ b/src/schemas/complaint-evidence.schema.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const submitEvidenceSchema = z.object({
+  description: z
+    .string({ required_error: "Descrição é obrigatória" })
+    .trim()
+    .min(20, "Descrição deve ter no mínimo 20 caracteres"),
+});

--- a/src/schemas/complaint-votes.schema.js
+++ b/src/schemas/complaint-votes.schema.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const voteSchema = z.object({
+  approved: z.boolean({ required_error: "Campo 'approved' é obrigatório" }),
+});

--- a/src/validators/complaint-evidence.validator.js
+++ b/src/validators/complaint-evidence.validator.js
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { submitEvidenceSchema } from "../schemas/complaint-evidence.schema.js";
+import { ValidationError } from "../shared/errors/validation.error.js";
+import { ERROR_CODES } from "../shared/types/error.codes.js";
+
+export const validateSubmitEvidence = (req, res, next) => {
+  const result = submitEvidenceSchema.safeParse(req.body);
+
+  if (!result.success) {
+    const errors = z.flattenError(result.error);
+    throw new ValidationError(errors, ERROR_CODES.COMPLAINT_VALIDATION);
+  }
+
+  if (!req.files || req.files.length === 0) {
+    throw new ValidationError(
+      "É obrigatório enviar pelo menos 1 foto como evidência",
+      ERROR_CODES.COMPLAINT_VALIDATION,
+    );
+  }
+
+  if (req.files.length > 5) {
+    throw new ValidationError(
+      "Máximo de 5 fotos permitidas",
+      ERROR_CODES.COMPLAINT_VALIDATION,
+    );
+  }
+
+  next();
+};

--- a/src/validators/complaint-votes.validator.js
+++ b/src/validators/complaint-votes.validator.js
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { voteSchema } from "../schemas/complaint-votes.schema.js";
+import { ValidationError } from "../shared/errors/validation.error.js";
+import { ERROR_CODES } from "../shared/types/error.codes.js";
+
+export const validateVote = (req, res, next) => {
+  const result = voteSchema.safeParse(req.body);
+
+  if (!result.success) {
+    const errors = z.flattenError(result.error);
+    throw new ValidationError(errors, ERROR_CODES.COMPLAINT_VALIDATION);
+  }
+
+  req.body.approved = result.data.approved;
+  next();
+};


### PR DESCRIPTION
  ## O que foi feito
  - Implementado módulo completo de evidências (controller, service, repository, schema, validator)
  - Upload de fotos via multipart/form-data com endpoint de envio de evidência
  - Listagem de evidências por denúncia com sorting in-memory (evita dependência de Firestore composite index)
  - Validação individual de evidências aceita `{ approved, evidenceIds }` para aprovar/rejeitar por IDs
  específicos
  - Adicionado `rejectAllByComplaintId` para rejeição em lote
  - Implementado módulo completo de votação (controller, service, repository, schema, validator)
  - Adicionado Firestore composite index em `dev_complaint_evidence` (complaintId + createdAt)
  - Registradas novas rotas em `complaints.routes.js`
  
closes #120, #121, #122 