### PR TITLE
feat: add complaint validations count endpoint

### DIFF
--- a/src/modules/complaint-validations/complaint-validations.controller.js
+++ b/src/modules/complaint-validations/complaint-validations.controller.js
@@ -1,0 +1,9 @@
+import { StatusCodes } from "http-status-codes";
+import * as complaintValidationsService from "./complaint-validations.service.js";
+import { success } from "../../shared/utils/response.util.js";
+
+export const countByComplaintId = async (req, res) => {
+  const result = await complaintValidationsService.countByComplaintId(req.params.id);
+
+  return success(res, result, StatusCodes.OK);
+};

--- a/src/modules/complaint-validations/complaint-validations.repository.js
+++ b/src/modules/complaint-validations/complaint-validations.repository.js
@@ -1,0 +1,24 @@
+import { db } from "../../config/firebase.js";
+import { env } from "../../config/env.js";
+import { serialize } from "../../shared/utils/firestore.util.js";
+
+const COLLECTION = `${env.firebase.collectionPrefix}complaint_evidence`;
+
+export const getValidationsByComplaintId = async (complaintId) => {
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("complaintId", "==", complaintId)
+    .where("status", "==", "approved")
+    .get();
+
+  return snapshot.docs.map((doc) => serialize(doc.id, doc.data()));
+};
+
+export const countByComplaintId = async (complaintId) => {
+  const validations = await getValidationsByComplaintId(complaintId);
+
+  return {
+    count: validations.length,
+    validations,
+  };
+};

--- a/src/modules/complaint-validations/complaint-validations.service.js
+++ b/src/modules/complaint-validations/complaint-validations.service.js
@@ -1,0 +1,28 @@
+import * as complaintRepository from "../complaints/complaints.repository.js";
+import * as complaintValidationsRepository from "./complaint-validations.repository.js";
+import * as usersService from "../users/users.service.js";
+
+export const countByComplaintId = async (complaintId) => {
+  await complaintRepository.getDetail(complaintId);
+
+  const { count, validations } =
+    await complaintValidationsRepository.countByComplaintId(complaintId);
+
+  if (count === 0) {
+    return {
+      count: 0,
+      validators: [],
+    };
+  }
+
+  const userIds = [...new Set(validations.map((validation) => validation.userId))];
+
+  const usersById = await usersService.getUsernamesByIds(userIds);
+
+  const validators = userIds.map((userId) => usersById.get(userId)).filter(Boolean);
+
+  return {
+    count,
+    validators,
+  };
+};

--- a/src/routes/complaints.routes.js
+++ b/src/routes/complaints.routes.js
@@ -2,6 +2,7 @@ import { Router } from "express";
 import * as complaintController from "../modules/complaints/complaints.controller.js";
 import * as complaintEvidenceController from "../modules/complaint-evidence/complaint-evidence.controller.js";
 import * as complaintVotesController from "../modules/complaint-votes/complaint-votes.controller.js";
+import * as complaintValidationsController from "../modules/complaint-validations/complaint-validations.controller.js";
 import commentsRoutes from "./comments.routes.js";
 import { wrap } from "../shared/utils/async-handler.util.js";
 import { validateUploadImage } from "../validators/upload.validator.js";
@@ -37,6 +38,11 @@ router.post(
   validateUploadImage,
   validateSubmitEvidence,
   wrap(complaintEvidenceController.submitEvidence),
+);
+
+router.get(
+  "/:id/validations/count",
+  wrap(complaintValidationsController.countByComplaintId),
 );
 
 router.get("/:id/evidences", wrap(complaintEvidenceController.getByComplaintId));


### PR DESCRIPTION
## O que foi feito

* Criada rota pública `GET /api/complaints/:id/validations/count`
* Implementado controller, service e repository para contagem de validações
* Retorno da rota contendo:

  * `count`
  * `validators` (lista de usernames)
* Tratamento para denúncia inexistente retornando `404`
* Retorno padrão `{ count: 0, validators: [] }` quando não há validações

## Exemplos testados

### Denúncia com validação

```json
{
  "success": true,
  "data": {
    "count": 1,
    "validators": ["teste1"]
  }
}
```

### Denúncia sem validação

```json
{
  "success": true,
  "data": {
    "count": 0,
    "validators": []
  }
}
```

### Denúncia inexistente

```json
{
  "success": false,
  "message": "Recurso não encontrado",
  "errorCode": "COMPLAINT_NOT_FOUND"
}
```

closes #128
