### PR TITLE
feat: add confirm resolution endpoint

### DIFF
--- a/src/modules/complaints/complaints.controller.js
+++ b/src/modules/complaints/complaints.controller.js
@@ -59,3 +59,12 @@ export const getNearest = async (req, res) => {
   const responseData = z.array(complaintResponseSchema).parse(complaints);
   return success(res, responseData, StatusCodes.OK);
 };
+
+/** @type {import("express").RequestHandler} */
+export const confirmResolution = async (req, res) => {
+  const complaint = await complaintService.confirmResolution(req.params.id, req.userId);
+
+  const responseData = complaintResponseSchema.parse(complaint);
+
+  return success(res, responseData, StatusCodes.OK);
+};

--- a/src/modules/complaints/complaints.repository.js
+++ b/src/modules/complaints/complaints.repository.js
@@ -4,6 +4,7 @@ import { NotFoundError } from "../../shared/errors/not-found.error.js";
 import { ERROR_CODES } from "../../shared/types/error.codes.js";
 import { serialize } from "../../shared/utils/firestore.util.js";
 import { distanceBetween } from "geofire-common";
+import { COMPLAINT_STATUS } from "../../shared/types/complaint.status.js";
 
 const COLLECTION = `${env.firebase.collectionPrefix}complaints`;
 
@@ -111,4 +112,22 @@ export const findNearestWithinRadius = async (lat, lng, radiusKm) => {
   results.sort((a, b) => a.distanceKm - b.distanceKm);
 
   return results;
+};
+
+export const confirmResolution = async (id) => {
+  const docRef = db.collection(COLLECTION).doc(id);
+  const doc = await docRef.get();
+
+  if (!doc.exists) throw new NotFoundError(ERROR_CODES.COMPLAINT_NOT_FOUND);
+
+  await docRef.update({
+    status: COMPLAINT_STATUS.RESOLVED,
+    resolvedAt: new Date(),
+    resolvedBy: "author",
+    updatedAt: new Date(),
+  });
+
+  const updatedDoc = await docRef.get();
+
+  return serialize(updatedDoc.id, updatedDoc.data());
 };

--- a/src/modules/complaints/complaints.service.js
+++ b/src/modules/complaints/complaints.service.js
@@ -8,6 +8,7 @@ import { ERROR_CODES } from "../../shared/types/error.codes.js";
 import * as complaintFollowersRepository from "../complaint-followers/complaint-followers.repository.js";
 import * as usersService from "../users/users.service.js";
 import * as notificationsService from "../notifications/notifications.service.js";
+import * as complaintValidationsRepository from "../complaint-validations/complaint-validations.repository.js";
 
 const VALID_TRANSITIONS = {
   [COMPLAINT_STATUS.OPEN]: [COMPLAINT_STATUS.IN_PROGRESS],
@@ -143,4 +144,36 @@ export const getFollowedByUsername = async (username) => {
   if (complaintIds.length === 0) return [];
 
   return await complaintRepository.getByIds(complaintIds);
+};
+
+const MIN_VALIDATIONS_TO_CONFIRM_RESOLUTION = 3;
+
+export const confirmResolution = async (complaintId, authenticatedUserId) => {
+  const complaint = await complaintRepository.getDetail(complaintId);
+
+  if (complaint.createdById !== authenticatedUserId) {
+    throw new ForbiddenError("Apenas o autor pode confirmar a resolução.");
+  }
+
+  if (complaint.status !== COMPLAINT_STATUS.AWAITING_VALIDATION) {
+    throw new ValidationError(
+      { fieldErrors: {} },
+      ERROR_CODES.VALIDATION_ERROR,
+      "A denúncia precisa estar aguardando validação.",
+    );
+  }
+
+  const { count } = await complaintValidationsRepository.countByComplaintId(complaintId);
+
+  if (count < MIN_VALIDATIONS_TO_CONFIRM_RESOLUTION) {
+    throw new ValidationError(
+      { fieldErrors: {} },
+      ERROR_CODES.VALIDATION_ERROR,
+      "Validações insuficientes para confirmar resolução.",
+    );
+  }
+
+  const updated = await complaintRepository.confirmResolution(complaintId);
+
+  return await usersService.enrichWithCreatedByUsername(updated);
 };

--- a/src/routes/complaints.routes.js
+++ b/src/routes/complaints.routes.js
@@ -66,6 +66,12 @@ router.get(
   wrap(complaintVotesController.getStatus),
 );
 
+router.post(
+  "/:id/confirm-resolution",
+  authenticateToken,
+  wrap(complaintController.confirmResolution),
+);
+
 router.get("/:id", wrap(complaintController.getDetail));
 
 router.patch(


### PR DESCRIPTION
## O que foi feito

Implementado endpoint `POST /api/complaints/:id/confirm-resolution`.

## Funcionalidades implementadas

* Criação da rota de confirmação de resolução.
* Validação de autenticação do utilizador.
* Validação para permitir apenas o autor da denúncia confirmar a resolução.
* Verificação do status atual da denúncia (`aguardando_validacao`).
* Verificação da quantidade mínima de validações necessárias (3).
* Atualização automática do status para `resolvido`.
* Registro de:

  * `resolvedAt`
  * `resolvedBy: "author"`

## Regras implementadas

* Retorna `403` quando outro utilizador tenta confirmar a resolução.
* Retorna `400` quando a denúncia não possui validações suficientes.
* Retorna `400` quando a denúncia não está em `aguardando_validacao`.

## Arquivos alterados

* `complaints.routes.js`
* `complaints.controller.js`
* `complaints.service.js`
* `complaints.repository.js`

## Issue relacionada

* Closes #129
