### PR TITLE
feat: confirm complaint resolution and notify followers

### DIFF
--- a/src/modules/complaint-validations/complaint-validations.repository.js
+++ b/src/modules/complaint-validations/complaint-validations.repository.js
@@ -2,13 +2,12 @@ import { db } from "../../config/firebase.js";
 import { env } from "../../config/env.js";
 import { serialize } from "../../shared/utils/firestore.util.js";
 
-const COLLECTION = `${env.firebase.collectionPrefix}complaint_evidence`;
+const COLLECTION = `${env.firebase.collectionPrefix}complaint_validations`;
 
 export const getValidationsByComplaintId = async (complaintId) => {
   const snapshot = await db
     .collection(COLLECTION)
     .where("complaintId", "==", complaintId)
-    .where("status", "==", "approved")
     .get();
 
   return snapshot.docs.map((doc) => serialize(doc.id, doc.data()));

--- a/src/modules/complaints/complaints.service.js
+++ b/src/modules/complaints/complaints.service.js
@@ -175,5 +175,13 @@ export const confirmResolution = async (complaintId, authenticatedUserId) => {
 
   const updated = await complaintRepository.confirmResolution(complaintId);
 
+  await notificationsService.notifyComplaintFollowers({
+    complaintId,
+    actorUserId: authenticatedUserId,
+    type: "complaint_resolved",
+    message: `A denúncia "${complaint.title}" foi marcada como resolvida pelo autor.`,
+    sendPush: false,
+  });
+
   return await usersService.enrichWithCreatedByUsername(updated);
 };

--- a/src/modules/notifications/notifications.service.js
+++ b/src/modules/notifications/notifications.service.js
@@ -31,6 +31,7 @@ export const createNotification = async ({
   const typeMap = {
     complaint_update: preferences.updates,
     status_change: preferences.statusChanges,
+    complaint_resolved: preferences.statusChanges,
     new_comment: preferences.comments,
     comment_group: preferences.comments,
     comment_reply: preferences.comments,


### PR DESCRIPTION
## O que foi implementado

### Issue #129 - Confirmar resolução da denúncia

* Criada rota `POST /api/complaints/:id/confirm-resolution`
* Validação para permitir apenas o autor da denúncia
* Verificação do status `aguardando_validacao`
* Verificação do mínimo de validações necessárias
* Atualização do status para `resolvido`
* Registro de confirmação da resolução

### Issue #130 - Notificar seguidores após resolução

* Notificação automática para seguidores após confirmação da resolução
* Exclusão do autor da lista de notificados
* Criação de notificação do tipo `complaint_resolved`
* Inclusão de referência da denúncia na notificação

## Critérios atendidos

### Issue #129

* [x] Apenas autor pode confirmar resolução
* [x] Retorna erro para validações insuficientes
* [x] Retorna erro para status inválido
* [x] Status atualizado para `resolvido`
* [x] Registro de confirmação salvo no documento

### Issue #130

* [x] Seguidores recebem notificação
* [x] Autor não recebe notificação
* [x] Notificação `complaint_resolved`
* [x] Referência da denúncia incluída
* [x] Fluxo sem erro quando não há seguidores

## Testes realizados

* Confirmação de resolução com token do autor
* Bloqueio para usuários não autores
* Verificação de validações mínimas
* Verificação de alteração de status
* Teste de criação de notificações
