### PR TITLE
fix: arruma restart dos containers e deixa rota publica

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,7 @@ services:
   nginx:
     image: nginx:alpine
     container_name: nginx
+    restart: always
     ports:
       - "80:80"
       - "443:443"
@@ -32,6 +33,7 @@ services:
   certbot:
     image: certbot/certbot
     container_name: certbot
+    restart: always
     volumes:
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot

--- a/src/routes/complaint-followers.routes.js
+++ b/src/routes/complaint-followers.routes.js
@@ -35,7 +35,6 @@ router.get(
 
 router.get(
   "/:complaintId",
-  authenticateToken,
   validateComplaintIdParam,
   wrap(complaintFollowersController.listByComplaint),
 );


### PR DESCRIPTION
Deixar rota publica para usuarios nao registrados e arrumar containers que não estavam reiniciando automaticamente.

closes #163