### PR TITLE
feat: add authorize roles middleware

### DIFF
--- a/src/routes/notifications.routes.js
+++ b/src/routes/notifications.routes.js
@@ -13,6 +13,9 @@ import {
 
 import * as notificationsController from "../modules/notifications/notifications.controller.js";
 
+import { USER_ROLES } from "../shared/constants/user-roles.js";
+import { authorizeRoles } from "../shared/middlewares/authorize-roles.middleware.js";
+
 const router = Router();
 
 /**
@@ -76,6 +79,7 @@ router.post(
   "/test",
   authenticateToken,
   requireVerifiedEmail,
+  authorizeRoles(USER_ROLES.ADMIN),
   wrap(notificationsController.createTestNotification),
 );
 

--- a/src/shared/middlewares/authorize-roles.middleware.js
+++ b/src/shared/middlewares/authorize-roles.middleware.js
@@ -1,0 +1,17 @@
+import { ForbiddenError } from "../errors/forbidden.error.js";
+import { getUserRole } from "../utils/user-role.js";
+import * as usersRepository from "../../modules/users/users.repository.js";
+
+export function authorizeRoles(...allowedRoles) {
+  return async (req, res, next) => {
+    const user = await usersRepository.getUserById(req.userId);
+    const role = getUserRole(user);
+
+    if (!allowedRoles.includes(role)) {
+      throw new ForbiddenError("Usuário sem permissão para acessar este recurso");
+    }
+
+    req.userRole = role;
+    next();
+  };
+}


### PR DESCRIPTION
## O que foi feito

- Criado o middleware `authorizeRoles`
- Adicionada validação da role do usuário autenticado
- Permite uma ou mais roles autorizadas
- Retorna erro 403 quando o usuário não possui permissão
- Aplicado o middleware em rota administrativa
- Reutilização preparada para outras rotas protegidas

## Como testar

1. Faça login com um usuário comum (`role: user`).
2. Acesse uma rota protegida pelo middleware.
3. Verifique que a resposta é `403 Forbidden`.
4. Faça login com um usuário `admin`.
5. Acesse a mesma rota.
6. Verifique que o acesso é permitido.

## Checklist

- [x] Middleware criado
- [x] Validação de roles implementada
- [x] Suporte a múltiplas roles
- [x] Retorno 403 para usuários sem permissão
- [x] Middleware aplicado em rota administrativa