### PR TITLE
feat: support anonymous complaints

### DIFF
--- a/src/modules/users/users.service.js
+++ b/src/modules/users/users.service.js
@@ -108,12 +108,15 @@ export const enrichWithUsername = async (item) => {
 export const enrichWithCreatedByUsernames = async (items) => {
   if (items.length === 0) return [];
 
-  const userIds = items.map((item) => item.createdById).filter(Boolean);
+  const visibleItems = items.filter((item) => !item.isAnonymous);
+  const userIds = visibleItems.map((item) => item.createdById).filter(Boolean);
   const usersById = await getUsernamesByIds(userIds);
 
   return items.map((item) => ({
     ...item,
-    createdByUsername: usersById.get(item.createdById) ?? null,
+    createdByUsername: item.isAnonymous
+      ? null
+      : (usersById.get(item.createdById) ?? null),
   }));
 };
 

--- a/src/schemas/complaint.schema.js
+++ b/src/schemas/complaint.schema.js
@@ -24,6 +24,13 @@ const complaintBaseSchema = z.object({
   location: locationSchema,
   photos: z.array(z.string()).optional(),
   thumbnailPhotos: z.array(z.string()).optional(),
+  isAnonymous: z
+    .preprocess((value) => {
+      if (value === true || value === "true") return true;
+      if (value === false || value === "false") return false;
+      return false;
+    }, z.boolean())
+    .default(false),
 });
 
 export const createComplaintSchema = complaintBaseSchema.refine(


### PR DESCRIPTION
## O que foi feito

- Adicionado suporte ao campo `isAnonymous` na API
- Corrigida a conversão do campo booleano recebido via multipart/form-data
- Mantido o vínculo interno com o usuário (`createdById`)
- Ocultado o `createdByUsername` para denúncias anônimas

## Testes realizados

- ✅ Criação de denúncia com anonimato desativado
- ✅ Criação de denúncia com anonimato ativado
- ✅ Teste pelo aplicativo mobile
- ✅ Verificado que denúncias anônimas exibem "Usuário anônimo"
- ✅ Verificado que denúncias não anônimas continuam exibindo o autor